### PR TITLE
chore: upgrade to pnpm 11 + 3-day minimum release age

### DIFF
--- a/apps/calculator-utils/package.json
+++ b/apps/calculator-utils/package.json
@@ -38,8 +38,5 @@
     "unplugin-icons": "catalog:",
     "vite": "catalog:",
     "vitest": "catalog:"
-  },
-  "engines": {
-    "pnpm": ">=10"
   }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -45,8 +45,5 @@
     "typescript": "catalog:",
     "vite": "catalog:",
     "vitest": "catalog:"
-  },
-  "engines": {
-    "pnpm": ">=10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "*.{js,jsx,ts,tsx,svelte,css,json,md}": "oxfmt --no-error-on-unmatched-pattern"
   },
   "engines": {
-    "pnpm": ">=10"
+    "pnpm": ">=11"
   },
-  "packageManager": "pnpm@10.34.3"
+  "packageManager": "pnpm@11.9.0"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,44 @@ packages:
   - 'apps/*'
   - 'packages/*'
 
+minimumReleaseAge: 4320
+minimumReleaseAgeExclude:
+  - '@sanity/*'
+  - 'sanity'
+  - '@portabletext/*'
+  - '@rolldown/*'
+  - 'rolldown'
+  - '@tybys/wasm-util'
+  - '@sentry/*'
+  - '@oclif/*'
+  - '@napi-rs/*'
+  - '@oxfmt/*'
+  - '@turbo/*'
+  - '@typescript-eslint/*'
+  - '@testing-library/*'
+  - '@sveltejs/*'
+  - '@playwright/*'
+  - '@vitejs/*'
+  - '@iconify/*'
+  - 'happy-dom'
+  - 'svelte'
+  - 'svelte-check'
+  - 'svelte-highlight'
+  - 'vite'
+  - 'turbo'
+  - 'oxfmt'
+  - 'playwright'
+  - 'playwright-core'
+  - 'typescript-eslint'
+  - 'eslint-config-turbo'
+  - 'eslint-plugin-turbo'
+  - 'globals'
+  - 'groq'
+  - 'styled-components'
+
+allowBuilds:
+  esbuild: false
+
 catalog:
   '@sanity/client': '^7.23.0'
   '@sanity/image-url': '^2.1.1'

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>binoy14/renovate"],
-  "automerge": true
+  "automerge": true,
+  "minimumReleaseAge": "3 days"
 }


### PR DESCRIPTION
## Summary

- **Upgrade to pnpm 11** (`pnpm@11.9.0`); root `engines.pnpm` → `>=11`. Removed the redundant `engines` blocks from the `web`/`calculators` workspaces so the root manifest is the single source of truth.
- **`allowBuilds: { esbuild: false }`** — pnpm 11's pre-run deps check now *fails* on unapproved build scripts (it was only a warning under pnpm 10). This records the existing decision (esbuild's build script was never run) so `pnpm check`/`lint`/`test` don't error.
- **3-day minimum release age** (`minimumReleaseAge: 4320`) — packages must be published ≥ 3 days before they can be installed, to mitigate supply-chain attacks via freshly-published malicious versions.
- **Renovate mirrors the window** (`minimumReleaseAge: "3 days"`) so update PRs respect the same wait. This is the primary forward-looking protection: future lockfile updates will only contain aged packages.

## About the `minimumReleaseAgeExclude` list

pnpm 11 verifies the **committed lockfile** against the policy on every `--frozen-lockfile` install (i.e. CI). The current lockfile had a large dependency refresh < 3 days ago, so many entries would fail today. The exclude list is a **transitional bridge** to keep CI green now — most entries can be pruned once those versions age past 3 days. `@sanity/*`, `sanity`, and `@portabletext/*` are kept excluded by request.

> [!NOTE]
> Broad scope patterns (`@sentry/*`, `@sveltejs/*`, etc.) permanently exempt those names from the age check. They're listed because their current versions are < 3 days old; prune them later if you want the age check to apply to them going forward.

## Verification

- `pnpm install --frozen-lockfile` → ✓ passes supply-chain policies
- `pnpm check` / `pnpm lint` / `pnpm test` → all green
- Lockfile is **byte-identical to `main`** (no dependency versions changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)