### PR TITLE
fix(sanity): inline projectImage as an object instead of a referenced document

### DIFF
--- a/apps/sanity/migrations/delete-orphaned-project-images.ts
+++ b/apps/sanity/migrations/delete-orphaned-project-images.ts
@@ -1,0 +1,16 @@
+import { defineMigration, del } from 'sanity/migrate';
+
+/**
+ * Removes projectImage documents left behind by `inline-project-images`.
+ * Run this only after that migration has been applied and verified —
+ * it unconditionally deletes every remaining projectImage document.
+ */
+export default defineMigration({
+  title: 'Delete orphaned projectImage documents',
+  documentTypes: ['projectImage'],
+  migrate: {
+    document(doc) {
+      return del(doc._id);
+    },
+  },
+});

--- a/apps/sanity/migrations/inline-project-images.ts
+++ b/apps/sanity/migrations/inline-project-images.ts
@@ -1,0 +1,64 @@
+import { at, defineMigration, patch, set } from 'sanity/migrate';
+
+interface ProjectImageRef {
+  _key: string;
+  _type: string;
+  _ref?: string;
+}
+
+interface ProjectImageDoc {
+  _id: string;
+  alt?: string;
+  caption?: string;
+  image?: unknown;
+}
+
+/**
+ * projectImage moved from a referenced document type to an inline object type
+ * (see apps/sanity/src/schemas/projectImage.ts). This rewrites each project's
+ * projectImages array from {_type: 'reference', _ref} entries to inlined
+ * {_type: 'projectImage', alt, caption, image} objects.
+ *
+ * Note: context.client.getDocument() (and .clone().getDocument()) crash here
+ * with "Cannot read private member #httpRequest" — @sanity/migrate wraps the
+ * client in a Proxy that breaks methods relying on private class fields.
+ * context.client.fetch() is unaffected, so a GROQ join is used instead.
+ *
+ * Run `delete-orphaned-project-images` afterwards to remove the now-unused
+ * projectImage documents.
+ */
+export default defineMigration({
+  title: 'Inline projectImage references into project.projectImages',
+  documentTypes: ['project'],
+  filter: 'count(projectImages[_type == "reference"]) > 0',
+  migrate: {
+    async document(doc, context) {
+      const images = doc.projectImages as ProjectImageRef[];
+
+      const refIds = images.filter((item) => item._ref).map((item) => item._ref);
+
+      const referenced = await context.client.fetch<ProjectImageDoc[]>(
+        '*[_id in $ids]{_id, alt, caption, image}',
+        { ids: refIds },
+      );
+      const byId = new Map(referenced.map((ref) => [ref._id, ref]));
+
+      const next = images
+        .map((item) => {
+          if (item._type !== 'reference' || !item._ref) return item;
+          const ref = byId.get(item._ref);
+          if (!ref) return null;
+          return {
+            _key: item._key,
+            _type: 'projectImage',
+            alt: ref.alt,
+            caption: ref.caption,
+            image: ref.image,
+          };
+        })
+        .filter((item) => item !== null);
+
+      return patch(doc._id, at('projectImages', set(next)));
+    },
+  },
+});

--- a/apps/sanity/src/schemas/project.ts
+++ b/apps/sanity/src/schemas/project.ts
@@ -44,7 +44,7 @@ export default defineType({
       name: 'projectImages',
       title: 'Project Images',
       type: 'array',
-      of: [{ type: 'reference', to: [{ type: 'projectImage' }] }],
+      of: [{ type: 'projectImage' }],
     }),
   ],
   preview: {

--- a/apps/sanity/src/schemas/projectImage.ts
+++ b/apps/sanity/src/schemas/projectImage.ts
@@ -5,7 +5,7 @@ export default defineType({
   name: 'projectImage',
   title: 'Project Image',
   icon: MdImage,
-  type: 'document',
+  type: 'object',
   fields: [
     defineField({
       name: 'alt',

--- a/apps/web/src/lib/groq/getProjectBySlug.ts
+++ b/apps/web/src/lib/groq/getProjectBySlug.ts
@@ -11,8 +11,8 @@ const projectFields = `
     }
   },
   slug,
-  "projectImages": projectImages[]-> {
-    _id,
+  projectImages[] {
+    _key,
     alt,
     caption,
     image {

--- a/apps/web/src/lib/groq/sanity-schema.json
+++ b/apps/web/src/lib/groq/sanity-schema.json
@@ -193,104 +193,6 @@
   },
   {
     "name": "projectImage",
-    "type": "document",
-    "attributes": {
-      "_id": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "_type": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string",
-          "value": "projectImage"
-        }
-      },
-      "_createdAt": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "_updatedAt": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "_rev": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        }
-      },
-      "alt": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        },
-        "optional": false
-      },
-      "caption": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "string"
-        },
-        "optional": false
-      },
-      "image": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "object",
-          "attributes": {
-            "asset": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "inline",
-                "name": "sanity.imageAsset.reference"
-              },
-              "optional": true
-            },
-            "media": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "unknown"
-              },
-              "optional": true
-            },
-            "hotspot": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "inline",
-                "name": "sanity.imageHotspot"
-              },
-              "optional": true
-            },
-            "crop": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "inline",
-                "name": "sanity.imageCrop"
-              },
-              "optional": true
-            },
-            "_type": {
-              "type": "objectAttribute",
-              "value": {
-                "type": "string",
-                "value": "image"
-              }
-            }
-          }
-        },
-        "optional": false
-      }
-    }
-  },
-  {
-    "name": "sanity.imageCrop",
     "type": "type",
     "value": {
       "type": "object",
@@ -299,112 +201,71 @@
           "type": "objectAttribute",
           "value": {
             "type": "string",
-            "value": "sanity.imageCrop"
+            "value": "projectImage"
           }
         },
-        "top": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "number"
-          },
-          "optional": false
-        },
-        "bottom": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "number"
-          },
-          "optional": false
-        },
-        "left": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "number"
-          },
-          "optional": false
-        },
-        "right": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "number"
-          },
-          "optional": false
-        }
-      }
-    }
-  },
-  {
-    "name": "sanity.imageHotspot",
-    "type": "type",
-    "value": {
-      "type": "object",
-      "attributes": {
-        "_type": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string",
-            "value": "sanity.imageHotspot"
-          }
-        },
-        "x": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "number"
-          },
-          "optional": false
-        },
-        "y": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "number"
-          },
-          "optional": false
-        },
-        "height": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "number"
-          },
-          "optional": false
-        },
-        "width": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "number"
-          },
-          "optional": false
-        }
-      }
-    }
-  },
-  {
-    "type": "type",
-    "name": "projectImage.reference",
-    "value": {
-      "type": "object",
-      "attributes": {
-        "_ref": {
+        "alt": {
           "type": "objectAttribute",
           "value": {
             "type": "string"
-          }
-        },
-        "_type": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "string",
-            "value": "reference"
-          }
-        },
-        "_weak": {
-          "type": "objectAttribute",
-          "value": {
-            "type": "boolean"
           },
-          "optional": true
+          "optional": false
+        },
+        "caption": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string"
+          },
+          "optional": false
+        },
+        "image": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "object",
+            "attributes": {
+              "asset": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "inline",
+                  "name": "sanity.imageAsset.reference"
+                },
+                "optional": true
+              },
+              "media": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "unknown"
+                },
+                "optional": true
+              },
+              "hotspot": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "inline",
+                  "name": "sanity.imageHotspot"
+                },
+                "optional": true
+              },
+              "crop": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "inline",
+                  "name": "sanity.imageCrop"
+                },
+                "optional": true
+              },
+              "_type": {
+                "type": "objectAttribute",
+                "value": {
+                  "type": "string",
+                  "value": "image"
+                }
+              }
+            }
+          },
+          "optional": false
         }
-      },
-      "dereferencesTo": "projectImage"
+      }
     }
   },
   {
@@ -496,11 +357,99 @@
             },
             "rest": {
               "type": "inline",
-              "name": "projectImage.reference"
+              "name": "projectImage"
             }
           }
         },
         "optional": true
+      }
+    }
+  },
+  {
+    "name": "sanity.imageCrop",
+    "type": "type",
+    "value": {
+      "type": "object",
+      "attributes": {
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "sanity.imageCrop"
+          }
+        },
+        "top": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "number"
+          },
+          "optional": false
+        },
+        "bottom": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "number"
+          },
+          "optional": false
+        },
+        "left": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "number"
+          },
+          "optional": false
+        },
+        "right": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "number"
+          },
+          "optional": false
+        }
+      }
+    }
+  },
+  {
+    "name": "sanity.imageHotspot",
+    "type": "type",
+    "value": {
+      "type": "object",
+      "attributes": {
+        "_type": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "string",
+            "value": "sanity.imageHotspot"
+          }
+        },
+        "x": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "number"
+          },
+          "optional": false
+        },
+        "y": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "number"
+          },
+          "optional": false
+        },
+        "height": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "number"
+          },
+          "optional": false
+        },
+        "width": {
+          "type": "objectAttribute",
+          "value": {
+            "type": "number"
+          },
+          "optional": false
+        }
       }
     }
   },

--- a/apps/web/src/lib/groq/sanity.types.ts
+++ b/apps/web/src/lib/groq/sanity.types.ts
@@ -53,11 +53,7 @@ export type SanityImageAssetReference = {
 };
 
 export type ProjectImage = {
-  _id: string;
   _type: "projectImage";
-  _createdAt: string;
-  _updatedAt: string;
-  _rev: string;
   alt: string;
   caption: string;
   image: {
@@ -67,29 +63,6 @@ export type ProjectImage = {
     crop?: SanityImageCrop;
     _type: "image";
   };
-};
-
-export type SanityImageCrop = {
-  _type: "sanity.imageCrop";
-  top: number;
-  bottom: number;
-  left: number;
-  right: number;
-};
-
-export type SanityImageHotspot = {
-  _type: "sanity.imageHotspot";
-  x: number;
-  y: number;
-  height: number;
-  width: number;
-};
-
-export type ProjectImageReference = {
-  _ref: string;
-  _type: "reference";
-  _weak?: boolean;
-  [internalGroqTypeReferenceTo]?: "projectImage";
 };
 
 export type Project = {
@@ -106,8 +79,24 @@ export type Project = {
   projectImages?: Array<
     {
       _key: string;
-    } & ProjectImageReference
+    } & ProjectImage
   >;
+};
+
+export type SanityImageCrop = {
+  _type: "sanity.imageCrop";
+  top: number;
+  bottom: number;
+  left: number;
+  right: number;
+};
+
+export type SanityImageHotspot = {
+  _type: "sanity.imageHotspot";
+  x: number;
+  y: number;
+  height: number;
+  width: number;
 };
 
 export type Description = Array<{
@@ -317,10 +306,9 @@ export type AllSanitySchemaTypes =
   | Contact
   | SanityImageAssetReference
   | ProjectImage
+  | Project
   | SanityImageCrop
   | SanityImageHotspot
-  | ProjectImageReference
-  | Project
   | Description
   | ImageInfo
   | Slug
@@ -445,7 +433,7 @@ export type GetContactsResult = Array<{
 
 // Source: ../web/src/lib/groq/getProjectBySlug.ts
 // Variable: getProjectBySlug
-// Query: *[  _type == "project"  && slug.current == $slug  && !(_id in path("drafts.**"))  && _id in *[_type == "homepage"][0].projects[]._ref] {    _id,  title,  description,  featuredDescription,  featuredImage {    asset -> {      url,    }  },  slug,  "projectImages": projectImages[]-> {    _id,    alt,    caption,    image {      asset->{        ...,      }    }  }}[0]
+// Query: *[  _type == "project"  && slug.current == $slug  && !(_id in path("drafts.**"))  && _id in *[_type == "homepage"][0].projects[]._ref] {    _id,  title,  description,  featuredDescription,  featuredImage {    asset -> {      url,    }  },  slug,  projectImages[] {    _key,    alt,    caption,    image {      asset->{        ...,      }    }  }}[0]
 export type GetProjectBySlugResult = {
   _id: string;
   title: string;
@@ -458,7 +446,7 @@ export type GetProjectBySlugResult = {
   };
   slug: Slug;
   projectImages: Array<{
-    _id: string;
+    _key: string;
     alt: string;
     caption: string;
     image: {
@@ -490,7 +478,7 @@ export type GetProjectBySlugResult = {
 
 // Source: ../web/src/lib/groq/getProjectBySlug.ts
 // Variable: getProjectBySlugPreview
-// Query: *[  _type == "project"  && slug.current == $slug] {    _id,  title,  description,  featuredDescription,  featuredImage {    asset -> {      url,    }  },  slug,  "projectImages": projectImages[]-> {    _id,    alt,    caption,    image {      asset->{        ...,      }    }  }}[0]
+// Query: *[  _type == "project"  && slug.current == $slug] {    _id,  title,  description,  featuredDescription,  featuredImage {    asset -> {      url,    }  },  slug,  projectImages[] {    _key,    alt,    caption,    image {      asset->{        ...,      }    }  }}[0]
 export type GetProjectBySlugPreviewResult = {
   _id: string;
   title: string;
@@ -503,7 +491,7 @@ export type GetProjectBySlugPreviewResult = {
   };
   slug: Slug;
   projectImages: Array<{
-    _id: string;
+    _key: string;
     alt: string;
     caption: string;
     image: {
@@ -583,8 +571,8 @@ declare module "@sanity/client" {
     '*[_type == "blog" && defined(slug.current)] {\n  "slug": slug.current,\n  publishedAt\n} | order(publishedAt desc)': GetBlogSlugsResult;
     '*[_type == "blog"] {\n  title,\n  excerpt,\n  slug,\n  publishedAt,\n  "readingTime": round(length(pt::text(body)) / 5 / 200 )\n} | order(publishedAt desc)': GetBlogsResult;
     '*[_type == "contact" && !(_id in path("drafts.**"))] {\n  link,\n  title\n} | order(title asc)': GetContactsResult;
-    '*[\n  _type == "project"\n  && slug.current == $slug\n  && !(_id in path("drafts.**"))\n  && _id in *[_type == "homepage"][0].projects[]._ref\n] {\n  \n  _id,\n  title,\n  description,\n  featuredDescription,\n  featuredImage {\n    asset -> {\n      url,\n    }\n  },\n  slug,\n  "projectImages": projectImages[]-> {\n    _id,\n    alt,\n    caption,\n    image {\n      asset->{\n        ...,\n      }\n    }\n  }\n\n}[0]': GetProjectBySlugResult;
-    '*[\n  _type == "project"\n  && slug.current == $slug\n] {\n  \n  _id,\n  title,\n  description,\n  featuredDescription,\n  featuredImage {\n    asset -> {\n      url,\n    }\n  },\n  slug,\n  "projectImages": projectImages[]-> {\n    _id,\n    alt,\n    caption,\n    image {\n      asset->{\n        ...,\n      }\n    }\n  }\n\n}[0]': GetProjectBySlugPreviewResult;
+    '*[\n  _type == "project"\n  && slug.current == $slug\n  && !(_id in path("drafts.**"))\n  && _id in *[_type == "homepage"][0].projects[]._ref\n] {\n  \n  _id,\n  title,\n  description,\n  featuredDescription,\n  featuredImage {\n    asset -> {\n      url,\n    }\n  },\n  slug,\n  projectImages[] {\n    _key,\n    alt,\n    caption,\n    image {\n      asset->{\n        ...,\n      }\n    }\n  }\n\n}[0]': GetProjectBySlugResult;
+    '*[\n  _type == "project"\n  && slug.current == $slug\n] {\n  \n  _id,\n  title,\n  description,\n  featuredDescription,\n  featuredImage {\n    asset -> {\n      url,\n    }\n  },\n  slug,\n  projectImages[] {\n    _key,\n    alt,\n    caption,\n    image {\n      asset->{\n        ...,\n      }\n    }\n  }\n\n}[0]': GetProjectBySlugPreviewResult;
     '*[_type == "homepage"][0].projects[]-> {\n  _id,\n  featuredImage {\n    alt,\n    asset -> {\n      ...,\n    }\n  },\n  featuredDescription,\n  title,\n  slug\n}': GetProjectsResult;
     '*[_type == "homepage"][0].projects[]-> {\n  slug\n}': GetProjectSlugsResult;
   }

--- a/apps/web/src/routes/project/[slug]/+page.svelte
+++ b/apps/web/src/routes/project/[slug]/+page.svelte
@@ -32,7 +32,7 @@
   {/if}
 
   {#if project?.projectImages}
-    {#each project.projectImages as projectImage (projectImage._id)}
+    {#each project.projectImages as projectImage (projectImage._key)}
       <div class="grid justify-center gap-5">
         <h3 class="text-center text-lg font-bold">{projectImage.caption}</h3>
         <Image


### PR DESCRIPTION
projectImage was a top-level document type referenced from
project.projectImages, which meant every project image needed its own
draft/publish lifecycle and the web query had to dereference it. Convert
projectImage to an object type embedded directly in the array, matching the
existing imageInfo pattern used for featuredImage.

Includes the one-time migrations used to inline existing projectImage
references into project.projectImages and delete the now-orphaned
projectImage documents (already run against production and development).