### PR TITLE
perf(web): prioritize LCP image and self-host Fira Code

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@binoy/ui": "workspace:*",
+    "@fontsource/fira-code": "^5.3.0",
     "@iconify-json/fa": "^1.2.2",
     "@iconify-json/mdi": "^1.2.3",
     "@sanity/client": "catalog:",

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -1,5 +1,11 @@
 @import 'tailwindcss';
 
+@import '@fontsource/fira-code/300.css';
+@import '@fontsource/fira-code/400.css';
+@import '@fontsource/fira-code/500.css';
+@import '@fontsource/fira-code/600.css';
+@import '@fontsource/fira-code/700.css';
+
 @plugin '@tailwindcss/typography';
 
 @source '../../../packages/ui/components';

--- a/apps/web/src/app.html
+++ b/apps/web/src/app.html
@@ -8,12 +8,6 @@
     <link rel="icon" href="%sveltekit.assets%/favicon.ico" />
     <link rel="apple-touch-icon" href="%sveltekit.assets%/favicon.ico" />
     <link rel="manifest" href="%sveltekit.assets%/manifest.webmanifest" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@300;400;500;600;700&display=swap"
-      rel="stylesheet"
-    />
 
     %sveltekit.head%
   </head>

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -27,7 +27,7 @@
   <h2 class="mt-10 text-xl font-bold">Projects</h2>
 
   <Section type="dark" className="sm:grid-cols-projects mt-5 sm:grid sm:gap-10">
-    {#each projects as project (project._id)}
+    {#each projects as project, i (project._id)}
       <Card>
         <a href={resolve(`/project/${stegaClean(project.slug.current)}`)}>
           <h3 class="text-lg font-bold">{project.title}</h3>
@@ -42,6 +42,7 @@
                   layout="fullWidth"
                   background={project.featuredImage.asset.metadata?.lqip}
                   class="rounded-sm"
+                  priority={i === 0}
                 />
               {/if}
             </div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,6 +202,9 @@ importers:
       '@binoy/ui':
         specifier: workspace:*
         version: link:../../packages/ui
+      '@fontsource/fira-code':
+        specifier: ^5.3.0
+        version: 5.3.0
       '@iconify-json/fa':
         specifier: ^1.2.2
         version: 1.2.2
@@ -1334,6 +1337,9 @@ packages:
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@fontsource/fira-code@5.3.0':
+    resolution: {integrity: sha512-EJL968RJRkakubAj/coU8pSUaeTE5UNoRjtzAr6kGiSZ3jWuN8/AKWHwym/PFUaQL1q7IL/H+EXs4358YhrTBQ==}
 
   '@fontsource/roboto@5.2.10':
     resolution: {integrity: sha512-8HlA5FtSfz//oFSr2eL7GFXAiE7eIkcGOtx7tjsLKq+as702x9+GU7K95iDeWFapHC4M2hv9RrpXKRTGGBI8Zg==}
@@ -7652,6 +7658,8 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
 
   '@floating-ui/utils@0.2.11': {}
+
+  '@fontsource/fira-code@5.3.0': {}
 
   '@fontsource/roboto@5.2.10': {}
 


### PR DESCRIPTION
Mobile PageSpeed Insights flagged two issues on the homepage:

- The first project card image (the LCP element) was rendered with
  @unpic/svelte's default loading="lazy", adding ~1.5s of resource
  load delay before the browser even started fetching it. It now gets
  priority={i === 0}, which sets loading="eager" + fetchpriority="high"
  for that image only.
- Fira Code was loaded via Google's CSS proxy (fonts.googleapis.com ->
  fonts.gstatic.com), a two-hop render-blocking chain costing ~590ms
  under slow-4G throttling. It's now self-hosted via @fontsource/fira-code,
  served from the same origin as everything else.