### PR TITLE
perf(web): trim Fira Code to latin-only subsets

### DIFF
--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -1,10 +1,9 @@
 @import 'tailwindcss';
 
-@import '@fontsource/fira-code/300.css';
-@import '@fontsource/fira-code/400.css';
-@import '@fontsource/fira-code/500.css';
-@import '@fontsource/fira-code/600.css';
-@import '@fontsource/fira-code/700.css';
+@import '@fontsource/fira-code/latin-400.css';
+@import '@fontsource/fira-code/latin-500.css';
+@import '@fontsource/fira-code/latin-600.css';
+@import '@fontsource/fira-code/latin-700.css';
 
 @plugin '@tailwindcss/typography';
 


### PR DESCRIPTION
Self-hosting Fira Code (#384) still imported the full multi-subset
fontsource CSS for each weight (cyrillic, cyrillic-ext, greek,
greek-ext, latin, latin-ext, symbols2), even though the site only
ever renders Latin text. That bundle was flagged by PageSpeed as a
630ms/24.5KiB render-blocking request.

Switch to the latin-only per-weight files and drop the unused 300
(Light) weight, which nothing in the codebase references. Cuts the
font-face CSS from ~35 @font-face rules to 4, shrinking the gzipped
bundle from ~24.5KiB to ~5KiB.