### PR TITLE
refactor: redesign site with a new aesthetic

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,7 +15,8 @@
   },
   "dependencies": {
     "@binoy/ui": "workspace:*",
-    "@fontsource/fira-code": "^5.3.0",
+    "@fontsource/ibm-plex-mono": "^5.3.0",
+    "@fontsource/ibm-plex-sans": "^5.3.0",
     "@iconify-json/fa": "^1.2.2",
     "@iconify-json/mdi": "^1.2.3",
     "@sanity/client": "catalog:",

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -101,27 +101,21 @@ body {
 }
 
 @keyframes gen-fade {
-  0% {
+  from {
     opacity: 0;
   }
-  20% {
+  to {
     opacity: 1;
-  }
-  60% {
-    opacity: 1;
-  }
-  100% {
-    opacity: 0;
   }
 }
 
 @keyframes dot-pulse {
   0%,
   100% {
-    opacity: 0.25;
+    opacity: 1;
   }
   50% {
-    opacity: 1;
+    opacity: 0.3;
   }
 }
 
@@ -149,13 +143,12 @@ body {
 
 .gen-line {
   opacity: 0;
-  animation: gen-fade 0.9s ease forwards;
+  animation: gen-fade 0.3s ease forwards;
   animation-delay: 1.3s;
 }
 
 .gen-dot {
-  animation: dot-pulse 0.3s ease-in-out 3;
-  animation-delay: 1.3s;
+  animation: dot-pulse 0.35s ease-in-out 4;
 }
 
 .project-card {

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -90,7 +90,7 @@ body {
     width: 0;
   }
   to {
-    width: 26ch;
+    width: 25ch;
   }
 }
 
@@ -134,10 +134,10 @@ body {
   display: inline-block;
   overflow: hidden;
   white-space: nowrap;
-  width: 26ch;
+  width: 25ch;
   border-right: 2px solid var(--color-terminal-accent);
   animation:
-    typing 1.3s steps(26, end) forwards,
+    typing 1.3s steps(25, end) forwards,
     caret 0.7s step-end infinite;
 }
 

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -1,9 +1,12 @@
 @import 'tailwindcss';
 
-@import '@fontsource/fira-code/latin-400.css';
-@import '@fontsource/fira-code/latin-500.css';
-@import '@fontsource/fira-code/latin-600.css';
-@import '@fontsource/fira-code/latin-700.css';
+@import '@fontsource/ibm-plex-sans/latin-400.css';
+@import '@fontsource/ibm-plex-sans/latin-500.css';
+@import '@fontsource/ibm-plex-sans/latin-600.css';
+@import '@fontsource/ibm-plex-mono/latin-400.css';
+@import '@fontsource/ibm-plex-mono/latin-500.css';
+@import '@fontsource/ibm-plex-mono/latin-600.css';
+@import '@fontsource/ibm-plex-mono/latin-700.css';
 
 @plugin '@tailwindcss/typography';
 
@@ -13,7 +16,14 @@
   --grid-template-columns-projects: repeat(auto-fit, minmax(450px, 1fr));
   --grid-template-columns-project-content: 250px 1fr;
 
-  --font-sans: var(--font-fira-code);
+  --color-terminal-bg: #0d0e10;
+  --color-terminal-panel: #111318;
+  --color-terminal-border: #22262c;
+  --color-terminal-text: #eef1ee;
+  --color-terminal-muted: #8b9290;
+  --color-terminal-accent: #6ee796;
+
+  --font-sans: var(--font-ibm-plex-sans);
   --font-sans--0: ui-sans-serif;
   --font-sans--1: system-ui;
   --font-sans--2: sans-serif;
@@ -22,6 +32,13 @@
   --font-sans--5: 'Segoe UI Symbol';
   --font-sans--6: 'Noto Color Emoji';
   --font-sans--length: 7;
+
+  --font-mono: var(--font-ibm-plex-mono);
+  --font-mono--0: ui-monospace;
+  --font-mono--1: SFMono-Regular;
+  --font-mono--2: Menlo;
+  --font-mono--3: monospace;
+  --font-mono--length: 4;
 }
 
 @utility container {
@@ -48,10 +65,110 @@
 }
 
 :root {
-  --font-fira-code: 'Fira Code';
+  --font-ibm-plex-sans: 'IBM Plex Sans';
+  --font-ibm-plex-mono: 'IBM Plex Mono';
 }
 
 body {
-  background-color: var(--color-black);
-  color: var(--color-white);
+  background-color: var(--color-terminal-bg);
+  color: var(--color-terminal-text);
+}
+
+@keyframes blink {
+  0%,
+  49% {
+    opacity: 1;
+  }
+  50%,
+  100% {
+    opacity: 0;
+  }
+}
+
+@keyframes typing {
+  from {
+    width: 0;
+  }
+  to {
+    width: 26ch;
+  }
+}
+
+@keyframes caret {
+  50% {
+    border-color: transparent;
+  }
+}
+
+@keyframes gen-fade {
+  0% {
+    opacity: 0;
+  }
+  20% {
+    opacity: 1;
+  }
+  60% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+@keyframes dot-pulse {
+  0%,
+  100% {
+    opacity: 0.25;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+@keyframes fadeUp {
+  from {
+    opacity: 0;
+    transform: translateY(14px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.typed-cmd {
+  display: inline-block;
+  overflow: hidden;
+  white-space: nowrap;
+  width: 26ch;
+  border-right: 2px solid var(--color-terminal-accent);
+  animation:
+    typing 1.3s steps(26, end) forwards,
+    caret 0.7s step-end infinite;
+}
+
+.gen-line {
+  opacity: 0;
+  animation: gen-fade 0.9s ease forwards;
+  animation-delay: 1.3s;
+}
+
+.gen-dot {
+  animation: dot-pulse 0.3s ease-in-out 3;
+  animation-delay: 1.3s;
+}
+
+.project-card {
+  opacity: 0;
+  animation: fadeUp 0.55s ease forwards;
+  transition:
+    transform 0.25s ease,
+    box-shadow 0.25s ease;
+}
+
+.project-card:hover {
+  transform: translateY(-4px) scale(1.015);
+  box-shadow:
+    0 0 0 1px var(--color-terminal-accent),
+    0 20px 40px rgb(110 231 150 / 15%);
 }

--- a/apps/web/src/lib/Navigation.svelte
+++ b/apps/web/src/lib/Navigation.svelte
@@ -19,23 +19,30 @@
     navOpen = !navOpen;
   }
 
-  let linkClasses = classnames('hover:underline', 'hover:text-yellow-400');
+  let linkClasses = classnames('font-mono', 'text-xs', 'transition-colors');
+
+  function linkColorClasses(link: string) {
+    const isActive = $page.url.pathname === `/${link}`;
+    return classnames(linkClasses, {
+      'text-terminal-accent': isActive,
+      'text-terminal-muted hover:text-terminal-text': !isActive,
+    });
+  }
 </script>
 
-<nav class="container">
-  <div class="flex h-24 w-full items-center bg-black text-white transition-all sm:h-36">
-    <a class="flex-1" href={resolve('/')}>
-      <h2 class="text-4xl">{title}</h2>
+<nav class="border-terminal-border bg-terminal-bg sticky top-0 z-10 border-b transition-all">
+  <div class="container flex h-14 w-full items-center justify-between">
+    <a class="flex flex-1 items-center gap-2.5" href={resolve('/')} aria-label={title}>
+      <span class="inline-block h-2.5 w-2.5 rounded-full bg-[#ff5f57]"></span>
+      <span class="inline-block h-2.5 w-2.5 rounded-full bg-[#febc2e]"></span>
+      <span class="inline-block h-2.5 w-2.5 rounded-full bg-[#28c840]"></span>
+      <span class="text-terminal-muted ml-2 font-mono text-xs">bash — {title}</span>
     </a>
     <!-- Desktop Nav -->
-    <ul class="hidden sm:flex">
+    <ul class="hidden gap-6 sm:flex">
       {#each links as navLink (navLink.link)}
-        <li
-          class={classnames(linkClasses, 'mr-6', 'last:mr-0', {
-            'text-yellow-400': $page.url.pathname === `/${navLink.link}`,
-          })}
-        >
-          <a href={resolve(`/${navLink.link}` as '/')}>{navLink.text}</a>
+        <li class={linkColorClasses(navLink.link)}>
+          <a href={resolve(`/${navLink.link}` as '/')}>./{navLink.text.toLowerCase()}</a>
         </li>
       {/each}
     </ul>
@@ -43,7 +50,7 @@
     <div class="sm:hidden">
       <button
         type="button"
-        class="inline-flex items-center justify-center rounded-md p-2 text-white hover:text-yellow-400"
+        class="text-terminal-muted hover:text-terminal-accent inline-flex items-center justify-center rounded-md p-2"
         aria-controls="mobile-menu"
         aria-expanded="false"
         onclick={onNavClick}
@@ -57,34 +64,27 @@
       </button>
     </div>
   </div>
-</nav>
 
-<ul
-  class={classnames(
-    'flex',
-    'flex-col',
-    'items-center',
-    'sm:hidden',
-    'bg-black',
-    'text-white',
-    'transition-all',
-    {
-      'max-h-52': navOpen === true,
-      'pb-4': navOpen === true,
-      'max-h-0': navOpen === false,
-    },
-  )}
->
-  {#if navOpen}
+  <ul
+    class={classnames(
+      'container',
+      'flex',
+      'flex-col',
+      'items-start',
+      'gap-4',
+      'overflow-hidden',
+      'sm:hidden',
+      'transition-all',
+      {
+        'max-h-52 pb-4': navOpen === true,
+        'max-h-0': navOpen === false,
+      },
+    )}
+  >
     {#each links as navLink (navLink.link)}
-      <li
-        class={classnames(linkClasses, 'mb-6', {
-          'text-yellow-400': $page.url.pathname === `/${navLink.link}`,
-        })}
-      >
-        <a class={`mb-6 ${linkClasses}`} href={resolve(`/${navLink.link}` as '/')}>{navLink.text}</a
-        >
+      <li class={linkColorClasses(navLink.link)}>
+        <a href={resolve(`/${navLink.link}` as '/')}>./{navLink.text.toLowerCase()}</a>
       </li>
     {/each}
-  {/if}
-</ul>
+  </ul>
+</nav>

--- a/apps/web/src/lib/Navigation.svelte
+++ b/apps/web/src/lib/Navigation.svelte
@@ -28,6 +28,10 @@
       'text-terminal-muted hover:text-terminal-text': !isActive,
     });
   }
+
+  let bashPath = $derived(
+    $page.url.pathname === '/' ? '/Users/binoy' : `/Users/binoy${$page.url.pathname}`,
+  );
 </script>
 
 <nav class="border-terminal-border bg-terminal-bg sticky top-0 z-10 border-b transition-all">
@@ -36,7 +40,7 @@
       <span class="inline-block h-2.5 w-2.5 rounded-full bg-[#ff5f57]"></span>
       <span class="inline-block h-2.5 w-2.5 rounded-full bg-[#febc2e]"></span>
       <span class="inline-block h-2.5 w-2.5 rounded-full bg-[#28c840]"></span>
-      <span class="text-terminal-muted ml-2 font-mono text-xs">bash — {title}</span>
+      <span class="text-terminal-muted ml-2 font-mono text-xs">bash — {bashPath}</span>
     </a>
     <!-- Desktop Nav -->
     <ul class="hidden gap-6 sm:flex">

--- a/apps/web/src/lib/blockContent/BlockContent.svelte
+++ b/apps/web/src/lib/blockContent/BlockContent.svelte
@@ -12,7 +12,18 @@
   let { value }: Props = $props();
 </script>
 
-<div class="prose prose-invert max-w-md! md:max-w-2xl! lg:max-w-none!">
+<div
+  class="prose prose-invert prose-headings:font-mono prose-headings:text-terminal-text prose-p:text-terminal-text prose-a:text-terminal-accent
+    prose-a:no-underline hover:prose-a:text-[#8ff2ae]
+    prose-strong:text-terminal-text prose-code:rounded prose-code:border
+    prose-code:border-terminal-border prose-code:bg-terminal-panel
+    prose-code:px-1.5 prose-code:py-0.5 prose-code:font-mono
+    prose-code:font-normal prose-code:before:content-none prose-code:after:content-none
+    prose-pre:border prose-pre:border-terminal-border prose-pre:bg-terminal-panel
+    prose-blockquote:border-terminal-accent prose-blockquote:text-terminal-muted prose-hr:border-terminal-border
+    max-w-md! font-sans
+    md:max-w-2xl! lg:max-w-none!"
+>
   <PortableText
     {value}
     components={{

--- a/apps/web/src/lib/groq/getBlogBySlug.ts
+++ b/apps/web/src/lib/groq/getBlogBySlug.ts
@@ -5,6 +5,7 @@ export const getBlogBySlug = groq`*[_type == "blog" && slug.current == $slug] {
   excerpt,
   slug,
   publishedAt,
+  "readingTime": round(length(pt::text(body)) / 5 / 200 ),
   body[]{
     ...,
     _type == "image" => {

--- a/apps/web/src/lib/groq/sanity.types.ts
+++ b/apps/web/src/lib/groq/sanity.types.ts
@@ -327,12 +327,13 @@ export type AllSanitySchemaTypes =
 
 // Source: ../web/src/lib/groq/getBlogBySlug.ts
 // Variable: getBlogBySlug
-// Query: *[_type == "blog" && slug.current == $slug] {  title,  excerpt,  slug,  publishedAt,  body[]{    ...,    _type == "image" => {      "asset": @.asset->{        ...      }    },    markDefs[]{      ...,      _type == "internalLink" => {        "slug": @.reference->slug      }    }  }}[0]
+// Query: *[_type == "blog" && slug.current == $slug] {  title,  excerpt,  slug,  publishedAt,  "readingTime": round(length(pt::text(body)) / 5 / 200 ),  body[]{    ...,    _type == "image" => {      "asset": @.asset->{        ...      }    },    markDefs[]{      ...,      _type == "internalLink" => {        "slug": @.reference->slug      }    }  }}[0]
 export type GetBlogBySlugResult = {
   title: string;
   excerpt: string;
   slug: Slug;
   publishedAt: string;
+  readingTime: number;
   body: Array<
     | {
         children?: Array<{
@@ -567,7 +568,7 @@ export type GetProjectSlugsResult = Array<{
 import "@sanity/client";
 declare module "@sanity/client" {
   interface SanityQueries {
-    '*[_type == "blog" && slug.current == $slug] {\n  title,\n  excerpt,\n  slug,\n  publishedAt,\n  body[]{\n    ...,\n    _type == "image" => {\n      "asset": @.asset->{\n        ...\n      }\n    },\n    markDefs[]{\n      ...,\n      _type == "internalLink" => {\n        "slug": @.reference->slug\n      }\n    }\n  }\n}[0]': GetBlogBySlugResult;
+    '*[_type == "blog" && slug.current == $slug] {\n  title,\n  excerpt,\n  slug,\n  publishedAt,\n  "readingTime": round(length(pt::text(body)) / 5 / 200 ),\n  body[]{\n    ...,\n    _type == "image" => {\n      "asset": @.asset->{\n        ...\n      }\n    },\n    markDefs[]{\n      ...,\n      _type == "internalLink" => {\n        "slug": @.reference->slug\n      }\n    }\n  }\n}[0]': GetBlogBySlugResult;
     '*[_type == "blog" && defined(slug.current)] {\n  "slug": slug.current,\n  publishedAt\n} | order(publishedAt desc)': GetBlogSlugsResult;
     '*[_type == "blog"] {\n  title,\n  excerpt,\n  slug,\n  publishedAt,\n  "readingTime": round(length(pt::text(body)) / 5 / 200 )\n} | order(publishedAt desc)': GetBlogsResult;
     '*[_type == "contact" && !(_id in path("drafts.**"))] {\n  link,\n  title\n} | order(title asc)': GetContactsResult;

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -36,13 +36,15 @@
 <PreviewMode enabled={previewEnabled}>
   <VisualEditing enabled={previewEnabled}>
     <QueryLoader enabled={previewEnabled} client={sanityClient}>
-      <Navigation {links} title="Binoy Patel" />
+      <div class="flex min-h-screen flex-col">
+        <Navigation {links} title="Binoy Patel" />
 
-      <main class="min-h-full min-w-full">
-        {@render children?.()}
-      </main>
+        <main class="min-w-full flex-1">
+          {@render children?.()}
+        </main>
 
-      <Footer />
+        <Footer />
+      </div>
     </QueryLoader>
   </VisualEditing>
 </PreviewMode>

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -35,7 +35,7 @@
 
 <div class="container pb-16">
   <p class="text-terminal-accent mb-2 font-mono text-sm">
-    <span class="typed-cmd">$ mcp call get_projects</span>
+    <span class="typed-cmd">$ mcp call get_projects()</span>
   </p>
   <p class="gen-line text-terminal-muted mb-5 h-4 font-mono text-xs">
     &gt; resolving {projects.length} project{projects.length === 1 ? '' : 's'}<span

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { Card, Section, TextBlock } from '@binoy/ui';
   import { Image } from '@unpic/svelte';
   import { resolve } from '$app/paths';
   import { useQuery, stegaClean } from '@sanity/sveltekit';
@@ -14,42 +13,67 @@
 
 <Seo jsonLd={[personJsonLd(), websiteJsonLd()]} />
 
-<Section type="light">
-  <div class="container">
-    <TextBlock
-      header="Hey 👋, I'm Binoy"
-      subtext="Full Stack Engineer crafting scalable, user-centric software solutions with 10+ years of hands-on expertise."
-    />
+<div class="relative overflow-hidden">
+  <div
+    class="pointer-events-none absolute inset-0"
+    style="background-image:repeating-linear-gradient(0deg,rgb(110 231 150 / 2.5%) 0px,rgb(110 231 150 / 2.5%) 1px,transparent 1px,transparent 3px)"
+  ></div>
+  <div class="relative container py-16 sm:py-20">
+    <p class="text-terminal-accent font-mono text-sm">$ whoami</p>
+    <h1 class="mt-2.5 font-mono text-4xl font-bold sm:text-5xl">
+      Binoy Patel<span
+        class="bg-terminal-accent ml-1.5 inline-block h-9 w-3 align-middle sm:h-11"
+        style="animation: blink 1s step-end infinite"
+      ></span>
+    </h1>
+    <p class="text-terminal-muted mt-5 max-w-xl font-mono text-base leading-relaxed">
+      Full Stack Engineer crafting scalable, user-centric software solutions with 10+ years of
+      hands-on expertise.
+    </p>
   </div>
-</Section>
+</div>
 
-<div class="container">
-  <h2 class="mt-10 text-xl font-bold">Projects</h2>
+<div class="container pb-16">
+  <p class="text-terminal-accent mb-2 font-mono text-sm">
+    <span class="typed-cmd">$ mcp call get_projects</span>
+  </p>
+  <p class="gen-line text-terminal-muted mb-5 h-4 font-mono text-xs">
+    &gt; resolving {projects.length} project{projects.length === 1 ? '' : 's'}<span
+      class="gen-dot"
+      style="animation-delay:1.3s">.</span
+    ><span class="gen-dot" style="animation-delay:1.5s">.</span><span
+      class="gen-dot"
+      style="animation-delay:1.7s">.</span
+    >
+  </p>
 
-  <Section type="dark" className="sm:grid-cols-projects mt-5 sm:grid sm:gap-10">
+  <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
     {#each projects as project, i (project._id)}
-      <Card>
-        <a href={resolve(`/project/${stegaClean(project.slug.current)}`)}>
-          <h3 class="text-lg font-bold">{project.title}</h3>
-          <div
-            class="sm:grid-cols-project-content flex h-full min-h-[390px] flex-col items-center sm:grid"
-          >
-            <div class="sm:mr-8">
-              {#if project.featuredImage.asset?.url}
-                <Image
-                  src={project.featuredImage.asset?.url}
-                  alt={project.featuredImage?.alt || project.featuredImage?.asset?.altText || ''}
-                  layout="fullWidth"
-                  background={project.featuredImage.asset.metadata?.lqip}
-                  class="rounded-sm"
-                  priority={i === 0}
-                />
-              {/if}
-            </div>
-            <p class="my-8">{project.featuredDescription}</p>
-          </div>
-        </a>
-      </Card>
+      <a
+        class="project-card border-terminal-border bg-terminal-panel flex flex-col overflow-hidden rounded-lg border text-inherit no-underline"
+        style="animation-delay:{1600 + i * 100}ms"
+        href={resolve(`/project/${stegaClean(project.slug.current)}`)}
+      >
+        <div class="bg-terminal-bg aspect-video w-full overflow-hidden">
+          {#if project.featuredImage.asset?.url}
+            <Image
+              src={project.featuredImage.asset?.url}
+              alt={project.featuredImage?.alt || project.featuredImage?.asset?.altText || ''}
+              layout="fullWidth"
+              objectFit="contain"
+              background={project.featuredImage.asset.metadata?.lqip}
+              class="h-full w-full"
+              priority={i === 0}
+            />
+          {/if}
+        </div>
+        <div class="flex flex-1 flex-col justify-center p-4">
+          <h3 class="font-mono text-sm font-semibold">{project.title}</h3>
+          <p class="text-terminal-muted mt-1.5 text-xs leading-relaxed">
+            {project.featuredDescription}
+          </p>
+        </div>
+      </a>
     {/each}
-  </Section>
+  </div>
 </div>

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -51,7 +51,7 @@
     {#each projects as project, i (project._id)}
       <a
         class="project-card border-terminal-border bg-terminal-panel flex flex-col overflow-hidden rounded-lg border text-inherit no-underline"
-        style="animation-delay:{1600 + i * 100}ms"
+        style="animation-delay:{3200 + i * 100}ms"
         href={resolve(`/project/${stegaClean(project.slug.current)}`)}
       >
         <div class="bg-terminal-bg aspect-video w-full overflow-hidden">

--- a/apps/web/src/routes/blogs/+page.svelte
+++ b/apps/web/src/routes/blogs/+page.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
-  import { Card } from '@binoy/ui';
   import { resolve } from '$app/paths';
   import { useQuery, stegaClean } from '@sanity/sveltekit';
   import type { GetBlogsResult } from '$lib/groq/sanity.types';
   import Seo from '$lib/Seo.svelte';
+
+  const description =
+    'Articles on full stack engineering, software architecture, and building for the web.';
 
   function getFormattedDate(publishedAt: string) {
     return new Date(publishedAt).toLocaleDateString('en-US', {
@@ -23,22 +25,34 @@
   const blogs = $derived($query.data ?? []);
 </script>
 
-<Seo
-  title="Blog"
-  description="Articles on full stack engineering, software architecture, and building for the web."
-/>
+<Seo title="Blog" {description} />
 
-<div class="container">
-  <h1 class="mt-10 mb-5 text-2xl font-bold">Blog</h1>
-  {#each blogs as blog (blog.slug)}
-    <Card className="my-10 py-10 px-10 first:mt-0">
-      <a href={resolve(`/blogs/${stegaClean(blog.slug.current)}`)}>
-        <h2 class="text-xl font-bold">{blog.title}</h2>
-      </a>
-      <h4 class="mt-2">
-        {getFormattedDate(blog.publishedAt)} - {getFormattedReadingTime(blog.readingTime)}
-      </h4>
-      <p class="mt-4 text-lg">{blog.excerpt}</p>
-    </Card>
+<div class="container max-w-4xl pt-16 pb-8">
+  <p class="text-terminal-accent font-mono text-sm">$ ls ./blogs</p>
+  <h1 class="mt-3.5 font-mono text-4xl font-bold">Blog</h1>
+  <p class="text-terminal-muted mt-4 max-w-lg font-mono text-sm leading-relaxed">
+    // {description}
+  </p>
+</div>
+
+<div class="container max-w-4xl pb-16">
+  {#each blogs as blog, i (blog.slug.current)}
+    <a
+      class="group border-terminal-border hover:bg-terminal-accent/5 -mx-4 block rounded-md border-t px-4 py-5.5 no-underline transition-colors"
+      class:border-b={i === blogs.length - 1}
+      href={resolve(`/blogs/${stegaClean(blog.slug.current)}`)}
+    >
+      <h2
+        class="text-terminal-text group-hover:text-terminal-accent font-mono text-base font-semibold transition-colors"
+      >
+        {stegaClean(blog.slug.current)}.md
+      </h2>
+      <p class="text-terminal-muted mt-1.5 font-mono text-xs">
+        {getFormattedDate(blog.publishedAt)} · {getFormattedReadingTime(blog.readingTime)}
+      </p>
+      <p class="text-terminal-muted mt-2 max-w-2xl text-sm leading-relaxed">
+        {blog.excerpt}
+      </p>
+    </a>
   {/each}
 </div>

--- a/apps/web/src/routes/blogs/+page.svelte
+++ b/apps/web/src/routes/blogs/+page.svelte
@@ -29,10 +29,7 @@
 
 <div class="container max-w-4xl pt-16 pb-8">
   <p class="text-terminal-accent font-mono text-sm">$ ls ./blogs</p>
-  <h1 class="mt-3.5 font-mono text-4xl font-bold">Blog</h1>
-  <p class="text-terminal-muted mt-4 max-w-lg font-mono text-sm leading-relaxed">
-    // {description}
-  </p>
+  <h1 class="mt-3.5 font-mono text-4xl font-bold">Blogs</h1>
 </div>
 
 <div class="container max-w-4xl pb-16">

--- a/apps/web/src/routes/blogs/[slug]/+page.svelte
+++ b/apps/web/src/routes/blogs/[slug]/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import BlockContent from '$lib/blockContent/BlockContent.svelte';
   import { type InputValue } from '@portabletext/svelte';
+  import { resolve } from '$app/paths';
   import { useQuery, stegaClean } from '@sanity/sveltekit';
   import type { GetBlogBySlugResult } from '$lib/groq/sanity.types';
   import Seo from '$lib/Seo.svelte';
@@ -41,11 +42,27 @@
   />
 {/if}
 
-<div class="container mb-10 grid gap-5">
-  <h1 class="text-2xl font-bold">{blog?.title}</h1>
-  <p class="text-xs italic">{blog?.publishedAt ? formatDate(blog.publishedAt) : ''}</p>
+{#if blog}
+  <div class="container max-w-3xl pt-14 pb-20">
+    <a
+      href={resolve('/blogs')}
+      class="text-terminal-muted font-mono text-[13px] transition-colors hover:text-[#8ff2ae]"
+    >
+      &larr; cat ~/blogs
+    </a>
 
-  {#if blogBody}
-    <BlockContent value={blogBody} />
-  {/if}
-</div>
+    <p class="text-terminal-accent mt-6 font-mono text-sm">
+      $ cat {stegaClean(blog.slug.current)}.md
+    </p>
+    <h1 class="mt-3.5 font-mono text-3xl font-bold sm:text-4xl">{blog.title}</h1>
+    <p class="text-terminal-muted mt-3 font-mono text-[13px]">
+      {formatDate(blog.publishedAt)} · {blog.readingTime} min read
+    </p>
+
+    {#if blogBody}
+      <div class="mt-9">
+        <BlockContent value={blogBody} />
+      </div>
+    {/if}
+  </div>
+{/if}

--- a/apps/web/src/routes/contact/+page.svelte
+++ b/apps/web/src/routes/contact/+page.svelte
@@ -32,11 +32,11 @@
         href={stegaClean(link)}
         target="_blank"
         rel="external noreferrer noopener"
-        class="group hover:bg-terminal-accent/5 flex gap-2 px-7 py-2.5 no-underline transition-colors"
+        class="group hover:bg-terminal-accent/5 flex flex-wrap gap-x-2 gap-y-1 py-2.5 pr-7 pl-11 no-underline transition-colors"
       >
-        <span class="text-terminal-text">"{stegaClean(title).toLowerCase()}"</span>
-        <span class="text-terminal-muted">:</span>
-        <span class="text-terminal-accent transition-colors group-hover:text-[#8ff2ae]">
+        <span class="text-terminal-text shrink-0">"{stegaClean(title).toLowerCase()}"</span>
+        <span class="text-terminal-muted shrink-0">:</span>
+        <span class="text-terminal-accent break-all transition-colors group-hover:text-[#8ff2ae]">
           "{getDisplayValue(link)}"
         </span>
       </a>

--- a/apps/web/src/routes/contact/+page.svelte
+++ b/apps/web/src/routes/contact/+page.svelte
@@ -1,25 +1,12 @@
 <script lang="ts">
-  import { Card } from '@binoy/ui';
-  import FaGithub from 'virtual:icons/fa/github';
-  import FaLinkedin from 'virtual:icons/fa/linkedin';
-  import FaTwitter from 'virtual:icons/fa/twitter';
-  import FaYoutube from 'virtual:icons/fa/youtube';
-  import MdEmail from 'virtual:icons/mdi/email';
   import { useQuery, stegaClean } from '@sanity/sveltekit';
   import type { GetContactsResult } from '$lib/groq/sanity.types';
   import Seo from '$lib/Seo.svelte';
 
-  const contactIcons = {
-    Twitter: FaTwitter,
-    Youtube: FaYoutube,
-    Email: MdEmail,
-    Github: FaGithub,
-    Linkedin: FaLinkedin,
-  } as const;
-
-  function getIcon(title: string) {
-    // Strip stega markers before using the value as an object key.
-    return contactIcons[stegaClean(title) as keyof typeof contactIcons];
+  function getDisplayValue(link: string) {
+    return stegaClean(link)
+      .replace(/^mailto:/, '')
+      .replace(/^https?:\/\//, '');
   }
 
   let { data } = $props();
@@ -32,21 +19,28 @@
   description="Get in touch with Binoy Patel — find me on GitHub, LinkedIn, X, YouTube, or by email."
 />
 
-<div class="container">
-  <Card>
-    <h1 class="text-2xl font-bold">Say Hello!</h1>
-    <div class="my-10 flex flex-wrap justify-center">
-      {#each contacts as { link, title } (link)}
-        {@const SvelteComponent = getIcon(title)}
-        <a
-          href={stegaClean(link)}
-          target="_blank"
-          rel="external noreferrer noopener"
-          class="mb-8 ml-8 first:ml-0"
-        >
-          <SvelteComponent class="h-11 w-11" />
-        </a>
-      {/each}
-    </div>
-  </Card>
+<div class="container max-w-2xl pt-16 pb-10">
+  <p class="text-terminal-accent font-mono text-sm">$ cat contact.json</p>
+  <h1 class="mt-3.5 font-mono text-4xl font-bold">Say hello 👋</h1>
+</div>
+
+<div class="container max-w-2xl pb-16">
+  <div class="border-terminal-border bg-terminal-panel rounded-lg border py-2 font-mono text-sm">
+    <p class="text-terminal-muted px-7 py-1.5">{'{'}</p>
+    {#each contacts as { link, title } (link)}
+      <a
+        href={stegaClean(link)}
+        target="_blank"
+        rel="external noreferrer noopener"
+        class="group hover:bg-terminal-accent/5 flex gap-2 px-7 py-2.5 no-underline transition-colors"
+      >
+        <span class="text-terminal-text">"{stegaClean(title).toLowerCase()}"</span>
+        <span class="text-terminal-muted">:</span>
+        <span class="text-terminal-accent transition-colors group-hover:text-[#8ff2ae]">
+          "{getDisplayValue(link)}"
+        </span>
+      </a>
+    {/each}
+    <p class="text-terminal-muted px-7 py-1.5">&#125;</p>
+  </div>
 </div>

--- a/apps/web/src/routes/project/[slug]/+page.svelte
+++ b/apps/web/src/routes/project/[slug]/+page.svelte
@@ -2,6 +2,7 @@
   import BlockContent from '$lib/blockContent/BlockContent.svelte';
   import { imageBuilder } from '$lib/sanityClient.js';
   import { Image } from '@unpic/svelte';
+  import { resolve } from '$app/paths';
   import { useQuery, stegaClean } from '@sanity/sveltekit';
   import type { GetProjectBySlugResult } from '$lib/groq/sanity.types';
   import Seo from '$lib/Seo.svelte';
@@ -25,26 +26,49 @@
   />
 {/if}
 
-<div class="container mb-10 grid gap-5">
-  <h1 class="text-2xl font-bold">{project?.title}</h1>
-  {#if project?.description}
-    <BlockContent value={project.description} />
-  {/if}
+{#if project}
+  <div class="container max-w-3xl pt-14 pb-20">
+    <a
+      href={resolve('/')}
+      class="text-terminal-muted font-mono text-[13px] transition-colors hover:text-[#8ff2ae]"
+    >
+      &larr; cd ~/projects
+    </a>
 
-  {#if project?.projectImages}
-    {#each project.projectImages as projectImage (projectImage._key)}
-      <div class="grid justify-center gap-5">
-        <h3 class="text-center text-lg font-bold">{projectImage.caption}</h3>
-        <Image
-          width={800}
-          height={600}
-          priority={false}
-          class="w-full object-contain!"
-          layout="fixed"
-          src={imageBuilder.image(projectImage.image).fit('max').url().toString()}
-          alt={projectImage.alt || ''}
-        />
+    <p class="text-terminal-accent mt-6 font-mono text-sm">$ cat project.json</p>
+    <h1 class="mt-3.5 font-mono text-4xl font-bold">{project.title}</h1>
+
+    {#if project.featuredDescription}
+      <p class="text-terminal-text mt-5 max-w-xl text-base leading-relaxed">
+        {project.featuredDescription}
+      </p>
+    {/if}
+
+    {#if project.description}
+      <div class="mt-9">
+        <BlockContent value={project.description} />
       </div>
-    {/each}
-  {/if}
-</div>
+    {/if}
+
+    {#if project.projectImages}
+      <div class="mt-13 grid gap-11">
+        {#each project.projectImages as projectImage (projectImage._key)}
+          <div>
+            {#if projectImage.caption}
+              <p class="text-terminal-muted font-mono text-[13px]">// {projectImage.caption}</p>
+            {/if}
+            <div class="border-terminal-border mt-3.5 overflow-hidden rounded-lg border">
+              <Image
+                priority={false}
+                class="w-full"
+                layout="fullWidth"
+                src={imageBuilder.image(projectImage.image).fit('max').url().toString()}
+                alt={projectImage.alt || ''}
+              />
+            </div>
+          </div>
+        {/each}
+      </div>
+    {/if}
+  </div>
+{/if}

--- a/packages/ui/components/Footer.svelte
+++ b/packages/ui/components/Footer.svelte
@@ -2,4 +2,8 @@
   const year = new Date().getFullYear();
 </script>
 
-<footer class="container mt-10 bg-black py-4 text-white">© {year} Binoy Patel</footer>
+<footer
+  class="border-terminal-border bg-terminal-bg text-terminal-muted container mt-10 border-t py-5 font-mono text-xs"
+>
+  © {year} Binoy Patel
+</footer>

--- a/packages/ui/components/Section.svelte
+++ b/packages/ui/components/Section.svelte
@@ -17,8 +17,8 @@
   class={classnames(
     'py-6',
     {
-      'bg-black text-white': type === 'dark',
-      'bg-white text-black': type === 'light',
+      'bg-terminal-bg text-terminal-text': type === 'dark',
+      'bg-terminal-panel text-terminal-text': type === 'light',
     },
     className,
   )}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,7 +202,10 @@ importers:
       '@binoy/ui':
         specifier: workspace:*
         version: link:../../packages/ui
-      '@fontsource/fira-code':
+      '@fontsource/ibm-plex-mono':
+        specifier: ^5.3.0
+        version: 5.3.0
+      '@fontsource/ibm-plex-sans':
         specifier: ^5.3.0
         version: 5.3.0
       '@iconify-json/fa':
@@ -1338,8 +1341,11 @@ packages:
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
-  '@fontsource/fira-code@5.3.0':
-    resolution: {integrity: sha512-EJL968RJRkakubAj/coU8pSUaeTE5UNoRjtzAr6kGiSZ3jWuN8/AKWHwym/PFUaQL1q7IL/H+EXs4358YhrTBQ==}
+  '@fontsource/ibm-plex-mono@5.3.0':
+    resolution: {integrity: sha512-eTgnZjZEGk1QtD3ZstF+Vclo2HLAni8YMy34/DxllwZvyz1lR/1RF/xTiAquOBO7MvqBx8D2Ig2WCPMVfdZu7Q==}
+
+  '@fontsource/ibm-plex-sans@5.3.0':
+    resolution: {integrity: sha512-CbE4CbbEEZJX860XyUiRpsksXIQR8Rp2XDva2VO53NJox9tVNtusrysd2x5YkUEY3ErQ66W1IiiQL8/wihhw5w==}
 
   '@fontsource/roboto@5.2.10':
     resolution: {integrity: sha512-8HlA5FtSfz//oFSr2eL7GFXAiE7eIkcGOtx7tjsLKq+as702x9+GU7K95iDeWFapHC4M2hv9RrpXKRTGGBI8Zg==}
@@ -7659,7 +7665,9 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
-  '@fontsource/fira-code@5.3.0': {}
+  '@fontsource/ibm-plex-mono@5.3.0': {}
+
+  '@fontsource/ibm-plex-sans@5.3.0': {}
 
   '@fontsource/roboto@5.2.10': {}
 


### PR DESCRIPTION
## Summary
- Rebuilds the homepage, blog list/post, contact, and project detail pages around a terminal/CLI theme (mock title bar with traffic-light dots, typed command lines, `$ ls`/`$ cat` flavor text) sourced from a Claude Design mockup, while keeping all existing Sanity-backed data flows unchanged.
- Switches site fonts from Fira Code to self-hosted IBM Plex Mono/Sans, and introduces a shared terminal color palette (`Section`/`Footer` in `@binoy/ui`) so nav/footer chrome is consistent across every route.
- Nav's `bash — ...` label now reflects the current path instead of a static site name, matching the pattern established by the new blog/project detail designs.
- Project screenshots move from a fixed-aspect box to `fullWidth` image layout so panels hug each image's real proportions instead of letterboxing.
- Footer now sticks to the bottom of the viewport on short pages.
- Homepage's loading sequence (typed command → "resolving N projects..." → project grid) reads as real terminal output: the status line persists as history, loading dots pulse in a wave and settle, and cards only cascade in after that settle completes.

## Test plan
- [x] `pnpm --filter web check` / `pnpm --filter web lint` / `pnpm --filter web build` all pass
- [x] Manually verified in-browser (desktop + mobile viewports) against live Sanity data: home, blogs list, blog post, contact, project detail
- [x] Lighthouse performance audit (baseline `main` vs. this branch, both production `vite preview` builds) across all 5 page types — no meaningful score regressions (±3 pts, normal noise), 0ms Total Blocking Time on both, JS bundle size unchanged; the only measurable cost is +75–225ms FCP/LCP from the two-font-family swap (IBM Plex Mono + Sans replacing Fira Code), which stays within "Good" Core Web Vitals thresholds

🤖 Generated with [Claude Code](https://claude.com/claude-code)